### PR TITLE
Remove usage of QUnit.addEvent() which is no longer available

### DIFF
--- a/src/qunit-assert-html.js
+++ b/src/qunit-assert-html.js
@@ -245,8 +245,8 @@
 				// Initialize the background iframe!
 				if ( !iframe || !iframeWin || !iframeDoc ) {
 					iframe = window.document.createElement( "iframe" );
-					QUnit.addEvent( iframe, "load", iframeLoaded );
-					QUnit.addEvent( iframe, "readystatechange", iframeReadied );
+					iframe.onload = iframeLoaded;
+					iframe.onreadystatechange = iframeReadied;
 					iframe.style.position = "absolute";
 					iframe.style.top = iframe.style.left = "-1000px";
 					iframe.height = iframe.width = 0;


### PR DESCRIPTION
QUnit 1.15.0 has removed addEvent() from being publicly accessible, so use browser events instead.
